### PR TITLE
Update example compose file network section

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,7 @@ services:
     restart: unless-stopped
     cap_add:
     - NET_ADMIN
-    networks:
-    - host
+    network_mode: host
     volumes:
     - /my-data/xlink-config/:/root/.xlink/
     container_name: xlink-kai


### PR DESCRIPTION
Having
```yaml
networks:
- host
```
causes docker-compose to error:
```
ERROR: Service "xlink" uses an undefined network "host"
```
Changing it to `network_mode: host` makes it function.